### PR TITLE
Fix Azure unsupported flicker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-shv",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Vue support for libshv-js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/vue-shv.ts
+++ b/src/vue-shv.ts
@@ -179,13 +179,11 @@ export function useShv(options: VueShvOptions) {
 
                 for (const workflow of workflows) {
                     const parsedWorkflow = OAuth2AzureWorkflowZod.safeParse(workflow);
-                    if (!parsedWorkflow.success) {
-                        continue;
+                    if (parsedWorkflow.success) {
+                        shvSessionStorage.value.azureWorkflow = parsedWorkflow.data;
+                        globalThis.location.replace(makePkce({...parsedWorkflow.data, azureCodeRedirect}).authorizeUrl());
+                        return;
                     }
-
-                    shvSessionStorage.value.azureWorkflow = parsedWorkflow.data;
-
-                    globalThis.location.replace(makePkce({...parsedWorkflow.data, azureCodeRedirect}).authorizeUrl());
                 }
 
                 noBrokerSupport();


### PR DESCRIPTION
We need to return after finding the workflow, otherwise noBrokerSupport() will run and set AzureUnsupported for a brief moment