### PR TITLE
Fix globalResource resetting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-shv",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Vue support for libshv-js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
We don't actually want to reset the resource on watcher cleanup, because that means resetting it everytime the user doesn't actively use the resource (i.e. having some kind of watchEffect on it). We just want to invalidate it when the connection becomes unavailable.