### PR TITLE
CI: Do not npm install

### DIFF
--- a/.github/workflows/check-version-bump.yml
+++ b/.github/workflows/check-version-bump.yml
@@ -25,7 +25,6 @@ jobs:
         id: version-check
         continue-on-error: ${{startsWith(github.head_ref, 'dependabot/')}}
         run: |
-          npm install --no-save semver
           PREVIOUS_COMMIT="${{github.event.pull_request.base.sha || github.event.before}}"
           git fetch origin "$PREVIOUS_COMMIT"
           echo Comparing version bump against "$PREVIOUS_COMMIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-shv",
-  "version": "8.0.3",
+  "version": "8.0.4",
   "description": "Vue support for libshv-js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
We do not need it for `npx semver`. Furthermore, if the npm install fails, the job thinks there's no version bump.