### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 # vim: sw=2
 name: Lint
+permissions:
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-shv",
-  "version": "8.0.5",
+  "version": "8.0.6",
   "description": "Vue support for libshv-js",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Potential fix for [https://github.com/silicon-heaven/vue-shv/security/code-scanning/2](https://github.com/silicon-heaven/vue-shv/security/code-scanning/2)

To fix this, explicitly set `permissions` for the workflow so the `GITHUB_TOKEN` is restricted to the minimal scope needed. This workflow only checks out code and runs `npm install` / `npm run` commands; it does not push commits, create releases, or modify issues/PRs. Therefore, `contents: read` is sufficient. Defining `permissions` at the root of the workflow applies to all jobs that don’t override it, covering both `type-check` and `xo` without changing their behavior.

The single best fix is to add a top-level `permissions:` block (at the same indentation level as `name`, `on`, and `jobs`) specifying `contents: read`. A natural place is right after the `name: Lint` line (line 2) and before `concurrency:` so that it’s clearly visible and applies globally. No imports or additional methods are needed; this is purely a YAML configuration change within `.github/workflows/lint.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
